### PR TITLE
Fix "Mismatched change set lengths" in history mapping

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -59,8 +59,8 @@ const historyField = StateField.define({
     if (isolate == "full" || isolate == "before") state = state.isolate()
 
     if (tr.annotation(Transaction.addToHistory) === false)
-      return tr.changes.length ? state.addMapping(tr.changes.desc) : state
-    
+      return !tr.changes.empty ? state.addMapping(tr.changes.desc) : state
+
     let event = HistEvent.fromTransaction(tr)
     let time = tr.annotation(Transaction.time)!, userEvent = tr.annotation(Transaction.userEvent)
     if (event)


### PR DESCRIPTION
Hi there! I've encountered a small issue while using the `collab` module of CodeMirror 6 (which has been amazing -- thank you!!) and wanted to attempt a fix.

I put together a small example of the error [here](https://observablehq.com/d/bfb921ec7e9294ea) with short instructions for reproducing it. From my very basic understanding / hypothesis, it seems like the mapping of `HistoryState` fails when an empty document with previous history events receives two separate updates that should not be added to undo/redo history. The first update is successful, but the second fails.

I've had success fixing the issue by slightly altering the `update` method of the `historyField` so that it invokes `HistoryState.addMapping` when an updating transaction with a falsy `addToHistory` annotation has _non-empty changes_ (rather than when the transaction starts with a document of falsy length, as I think is currently implemented.) I'm not confident I've interpreted the logic correctly or am aware of the potential ramifications of this change, but hopefully it's at least a start!

Thanks so much for the time + help!!